### PR TITLE
Revert "fix(helm): update external-dns ( 1.15.0 → 1.15.1 )"

### DIFF
--- a/kubernetes/main/apps/network/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/main/apps/network/external-dns/cloudflare/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 1.15.1
+      version: 1.15.0
       sourceRef:
         kind: HelmRepository
         name: external-dns

--- a/kubernetes/main/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/main/apps/network/external-dns/unifi/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 1.15.1
+      version: 1.15.0
       sourceRef:
         kind: HelmRepository
         name: external-dns


### PR DESCRIPTION
Reverts nea0d/homelab-ops#1072 due to https://github.com/kubernetes-sigs/external-dns/issues/5035